### PR TITLE
Fix gradle build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,5 +37,12 @@ Logging makes it to Logcat it's necessary to call:
 Logger.root.level = Level.ALL;
 ```
 
+## Building the Android example
+
+The Android sample bundled with this plugin now uses Gradle 8.5 together with
+the Android Gradle plugin 8.5.0. This toolchain supports running on **Java 21**,
+so you can keep your `JAVA_HOME` pointing at a JDK 21 installation when
+invoking `flutter build` or `flutter run`.
+
 ## Contributions
-Especially, given that this is the first package I published on pub.dev I'm happy about any pointers of how it can be improved. 
+Especially, given that this is the first package I published on pub.dev I'm happy about any pointers of how it can be improved.

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/example/README.md
+++ b/example/README.md
@@ -14,3 +14,9 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter, view our
 [online documentation](https://flutter.dev/docs), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Building on Android
+
+This example uses Gradle 8.5 which runs happily on **Java 21**. Ensure that
+`JAVA_HOME` points to a JDK 21 installation before running `flutter build` or
+`flutter run`.

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.0'
+        classpath 'com.android.tools.build:gradle:8.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
-#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -6,8 +6,8 @@ pluginManagement {
         gradlePluginPortal()
     }
     plugins {
-        id "com.android.application" version "8.0.0"
-        id "com.android.library" version "8.0.0"
+        id "com.android.application" version "8.5.0"
+        id "com.android.library" version "8.5.0"
         id "org.jetbrains.kotlin.android" version "1.8.21"
         id "dev.flutter.flutter-gradle-plugin" version "1.0.0" // adjust if needed
     }


### PR DESCRIPTION
## Summary
- allow building with Java 21 by upgrading Gradle wrappers and AGP
- mention the Java 21 requirement in the docs

## Testing
- `flutter test`
- `flutter build apk -v`

------
https://chatgpt.com/codex/tasks/task_e_684e8ca883148321b84810780ef9ac31